### PR TITLE
Update postgres DATABASE_URL as per psycopg2 requirements.

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,9 +15,11 @@ app = Flask(__name__, template_folder="templates")
 # "sqlite:///data.sqlite"
 # /// for relative path
 # //// for absolute path
-app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
-    "DATABASE_URL", "sqlite:///data.sqlite"
-)
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///data.sqlite")
+DATABASE_URL.replace("postgres://", "postgresql://", 1)
+
+app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URL
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "thisissecret")
 app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(hours=12)

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ app = Flask(__name__, template_folder="templates")
 # //// for absolute path
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///data.sqlite")
-DATABASE_URL.replace("postgres://", "postgresql://", 1)
+DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
 
 app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URL
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False


### PR DESCRIPTION
Postgres `DATABASE_URL` should start with `postgresql://` but in Heroku database it starts with `postres://` which can cause an Application error.


**Fix**
Instead to directly passing the environment variable, first load the variable and then replace `postgres://` with `postgresql://` using `str.replace` method.